### PR TITLE
Fix typo in second-to-last cell

### DIFF
--- a/01-Dask_delay.ipynb
+++ b/01-Dask_delay.ipynb
@@ -408,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask.distributed import Cient\n",
+    "from dask.distributed import Client\n",
     "from dask import delayed\n",
     "client = Client()"
    ]


### PR DESCRIPTION
`from dask.distributed import Cient` should be `from dask.distributed import Client`